### PR TITLE
Upgrades to React Router v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0 (2022-06-03)
+
+- Upgrades to React Router v6. As `useHistory` is not available anymore this is a breaking change.
+
 ## 1.1.0 (2022-02-17)
 
 - Implements `autoCloseTimeout`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you want to show an alert, you need to call `openAlert`, this function is pro
 
 ```javascript
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Passwordless } from 'meteor/quave:accounts-passwordless-react';
 import { useLoggedUser } from 'meteor/quave:logged-user-react';
 import { useAlert } from 'meteor/quave:alert-react-tailwind';
@@ -82,10 +82,10 @@ import { RoutePaths } from '../general/RoutePaths';
 export const Access = () => {
   const { openAlert } = useAlert();
   const { loggedUser } = useLoggedUser();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const onEnterToken = () => {
-    history.push(RoutePaths.HOME);
+    navigate(RoutePaths.HOME);
     openAlert('Welcome!');
   };
 
@@ -95,7 +95,7 @@ export const Access = () => {
         <h3 className="text-lg px-3 py-2 text-base font-medium">
           You are already authenticated.
         </h3>
-        <button onClick={() => history.push(RoutePaths.HOME)} type="button">
+        <button onClick={() => navigate(RoutePaths.HOME)} type="button">
           Go Home
         </button>
       </div>
@@ -105,7 +105,7 @@ export const Access = () => {
     <div className="flex flex-col items-center flex-grow">
       <Passwordless onEnterToken={onEnterToken} />
       <a
-        onClick={() => history.push(RoutePaths.HOME)}
+        onClick={() => navigate(RoutePaths.HOME)}
         className="mt-5 text-base font-medium text-indigo-700 hover:text-indigo-600 cursor-pointer"
       >
         <span aria-hidden="true"> &rarr;</span> Back to Home

--- a/alert-react-tailwind.js
+++ b/alert-react-tailwind.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useContext, useState } from 'react';
 import { getSettings } from "meteor/quave:settings";
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Transition } from '@headlessui/react';
 import InboxIcon from '@heroicons/react/outline/InboxIcon';
 import ExclamationCircleIcon from '@heroicons/react/outline/ExclamationCircleIcon';
@@ -103,7 +103,7 @@ export const Alert = () => {
     buttonLabel,
     isError,
   } = useAlert();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const clear = () => {
     setMessage('');
@@ -113,7 +113,7 @@ export const Alert = () => {
 
   const onButtonClick = () => {
     if (route) {
-      history.push(route);
+      navigate(route);
       clear();
     }
   };

--- a/package.js
+++ b/package.js
@@ -3,12 +3,12 @@
 Package.describe({
   name: 'quave:alert-react-tailwind',
   summary: 'Alert for React & Tailwind apps',
-  version: '1.1.0',
+  version: '2.0.0',
   git: 'https://github.com/quavedev/alert-react-tailwind',
 });
 
 Package.onUse((api) => {
-  api.versionsFrom('2.5.3');
+  api.versionsFrom('2.7.3');
 
   api.use('ecmascript');
   api.use('quave:settings@1.0.0');


### PR DESCRIPTION
React Router v6 is no longer exposing useHistory so we had to create this breaking change in order to keep it compatible with latest React Router.

If you are not using React Router v6 don't upgrade.